### PR TITLE
fix: add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
     "linter",
     "compatibility"
   ],
+  "homepage": "https://github.com/3846masa/stylelint-browser-compat#readme",
+  "bugs": {
+    "url": "https://github.com/3846masa/stylelint-browser-compat/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/3846masa/stylelint-browser-compat.git"
+  },
   "funding": "https://github.com/sponsors/3846masa",
   "license": "MIT",
   "author": "3846masa <3846masahiro+git@gmail.com>",


### PR DESCRIPTION
* closed https://github.com/3846masa/stylelint-browser-compat/issues/738