### PR TITLE
fix: returns "not supported" when supported version is "preview"

### DIFF
--- a/src/__tests__/properties/scrollbar-width/test.spec.ts
+++ b/src/__tests__/properties/scrollbar-width/test.spec.ts
@@ -13,7 +13,7 @@ testRule({
   config: [
     true,
     {
-      browserslist: 'ie 6',
+      browserslist: 'safari 17',
     },
   ],
   reject: [
@@ -29,7 +29,7 @@ testRule({
       endColumn: 18,
       message: messages.rejected(
         '"scrollbar-width" property',
-        'IE 6',
+        'Safari 17.0',
         'https://developer.mozilla.org/docs/Web/CSS/scrollbar-width',
       ),
     },

--- a/src/is_supported.ts
+++ b/src/is_supported.ts
@@ -41,6 +41,10 @@ export function isSupported(supportBlock: SupportBlock, target: Target, options:
     if (s.version_added.startsWith('≤')) {
       return true;
     }
+    /** @see {@link https://github.com/mdn/browser-compat-data/blob/v5.6.13/docs/data-guidelines/index.md#choosing-preview-values} */
+    if (s.version_added === 'preview') {
+      return false;
+    }
 
     const addedSemver = semver.minVersion(s.version_added);
     const targetSemver = semver.minVersion(target.version.toString(10));


### PR DESCRIPTION
I ran into an issue running stylelint in primer/view_components:

```
TypeError: Invalid comparator: preview
    at Comparator.parse (/Users/camertron/workspace/primer/view_components/node_modules/semver/classes/comparator.js:39:13)
    at new Comparator (/Users/camertron/workspace/primer/view_components/node_modules/semver/classes/comparator.js:23:10)
    at /Users/camertron/workspace/primer/view_components/node_modules/semver/classes/range.js:152:47
    at Array.map (<anonymous>)
    at Range.parseRange (/Users/camertron/workspace/primer/view_components/node_modules/semver/classes/range.js:152:35)
    at /Users/camertron/workspace/primer/view_components/node_modules/semver/classes/range.js:40:22
    at Array.map (<anonymous>)
    at new Range (/Users/camertron/workspace/primer/view_components/node_modules/semver/classes/range.js:40:8)
    at Object.minVersion (/Users/camertron/workspace/primer/view_components/node_modules/semver/ranges/min-version.js:6:11)
    at isSupported (/Users/camertron/workspace/primer/view_components/node_modules/stylelint-browser-compat/lib/is_supported.js:37:41)
```

It looks like the MDN browser data contains "invalid" (at least, according to semver) versions like "preview". This PR checks for version validity before attempting to call `minVersion`.