### PR TITLE
fix: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/3846masa/stylelint-browser-compat.git"
+    "url": "git+https://github.com/3846masa/stylelint-browser-compat.git"
   },
   "funding": "https://github.com/sponsors/3846masa",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Replace the package repository URL with the public HTTPS GitHub URL.
- Keep the change scoped to package metadata only.

## Validation

- `node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/3846masa/stylelint-browser-compat.git') process.exit(1)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json .`
